### PR TITLE
Endor Labs Version Upgrade: Bump github.com/lestrrat-go/jwx/v2 from v2.0.13 to v2.0.21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ require github.com/go-chi/chi/v5 v5.0.8
 
 require (
 	github.com/goccy/go-json v0.10.2 // indirect
-	github.com/lestrrat-go/jwx/v2 v2.0.13
+	github.com/lestrrat-go/jwx/v2 v2.0.21
 	github.com/lestrrat-go/option v1.0.1 // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
-	golang.org/x/sys v0.12.0 // indirect
+	golang.org/x/sys v0.18.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/lestrrat-go/iter v1.0.2 h1:gMXo1q4c2pHmC3dn8LzRhJfP1ceCbgSiT9lUydIzlt
 github.com/lestrrat-go/iter v1.0.2/go.mod h1:Momfcq3AnRlRjI5b5O8/G5/BvpzrhoFTZcn06fEOPt4=
 github.com/lestrrat-go/jwx/v2 v2.0.13 h1:XdxzJbudGaHEoNmyJACAT8aFCB+DmviiaiMoZwuJoUo=
 github.com/lestrrat-go/jwx/v2 v2.0.13/go.mod h1:UzXMzcV99p9/xe1JsIb336NJDGXLsleR+Qj3ucEDtfI=
+github.com/lestrrat-go/jwx/v2 v2.0.21 h1:jAPKupy4uHgrHFEdjVjNkUgoBKtVDgrQPB/h55FHrR0=
+github.com/lestrrat-go/jwx/v2 v2.0.21/go.mod h1:09mLW8zto6bWL9GbwnqAli+ArLf+5M33QLQPDggkUWM=
 github.com/lestrrat-go/option v1.0.0/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
 github.com/lestrrat-go/option v1.0.1 h1:oAzP2fvZGQKWkvHa1/SAcFolBEca1oN+mQ7eooNBEYU=
 github.com/lestrrat-go/option v1.0.1/go.mod h1:5ZHFbivi4xwXxhxY9XHDe2FHo6/Z7WWmtT7T5nBBp3I=
@@ -58,6 +60,8 @@ golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=
 golang.org/x/sys v0.12.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.18.0 h1:DBdB3niSjOA/O0blCZBqDefyWNYveAYMNF1Wum0DYQ4=
+golang.org/x/sys v0.18.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/term v0.5.0/go.mod h1:jMB1sMXY+tzblOD4FWmEbocvup2/aLOaQEp7JmGp78k=


### PR DESCRIPTION
<h1 align="center">
  Endor Labs Automated Dependency Update
</h1>

## Summary

This PR updates dependencies to improve security:

### 📦 Dependencies Updated

| Project | Dependency Name | Update Version (From ➡️ To) | Update Risk |    |
|---------|-----------------|----------------------------|-------------|----|
| [nztzsh/autopr_testing](https://app.staging.endorlabs.com/t/test_shiva.nitesh/projects/676027b25e15ac5c2d2c4996) | `github.com/lestrrat-go/jwx/v2` | `v2.0.13` ➡️ `v2.0.21` | `LOW` | [View Details](https://app.staging.endorlabs.com/t/test_shiva.nitesh/projects/676027b25e15ac5c2d2c4996/remediations?filter.search=github.com%2Flestrrat-go%2Fjwx%2Fv2) |

---

## Security Impact

### Summary of Fixed Issues

| Severity | Count |
|----------|-------|
| 🟠 Medium   | 3   |

<details>
  <summary>🔍 <b>Findings fixed in this pull request (Click to expand)</b> </summary>

| Advisory          | Dependency Reachability | Function Reachability | Severity    |
|-------------------|-------------------------|-----------------------|-------------|
| [GHSA-hj3v-m684-v259](https://app.staging.endorlabs.com/t/test_shiva.nitesh/findings/676027c1a1a3445cac389643) | Potentially Reachable | Potentially Reachable | 🟠 Medium |
| [GHSA-pvcr-v8j8-j5q3](https://app.staging.endorlabs.com/t/test_shiva.nitesh/findings/676027c1a1a3445cac389644) | Potentially Reachable | Potentially Reachable | 🟠 Medium |
| [GHSA-7f9x-gw85-8grf](https://app.staging.endorlabs.com/t/test_shiva.nitesh/findings/676027c15e15ac5c2d2c49c6) | Potentially Reachable | Potentially Reachable | 🟠 Medium |

</details>

---

### Reminders

- **Ignore**: If you don't wish to receive this update again, simply close this PR.
- **Test**: Remember to ensure your tests pass and ensure this change doesn't impact your application before you merge.

---

<p align="center">
  <sub>
    Generated by <a href="https://endorlabs.com/">Endor Labs
  </sub>
</p>
